### PR TITLE
bugfix - addCommentToStatusHistory changed status

### DIFF
--- a/Model/BTCPay/BTCPayService.php
+++ b/Model/BTCPay/BTCPayService.php
@@ -403,7 +403,7 @@ class BTCPayService
                         if ($marked) {
                             $comment .= ' Marked manually.';
                         }
-                        $order->addCommentToStatusHistory($comment, $settledStatus, true);
+                        $order->addCommentToStatusHistory($comment, false, true);
 
                         if ($invoice->isOverpaid()) {
                             $order->addCommentToStatusHistory('Payment confirmed: overpaid.');


### PR DESCRIPTION
There was one more thing I forgot to push. addCommentToStatusHistory() changed status even though I set it in my observer. So I changed the second argument to false. Can you please merge it? Thanks